### PR TITLE
Enhancement: Better docker container layers

### DIFF
--- a/Dockerfile.releaser
+++ b/Dockerfile.releaser
@@ -14,14 +14,15 @@ RUN adduser \
 
 FROM bitnami/minideb:buster
 
-ADD payd-server /bin
-ADD data/sqlite/migrations/ /migrations
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 RUN mkdir /paydb && chown -R appuser:appuser /paydb
 VOLUME /paydb
+
+ADD payd-server /bin
+ADD data/sqlite/migrations/ /migrations
 
 USER appuser:appuser
 

--- a/Dockerfile.releaser
+++ b/Dockerfile.releaser
@@ -21,8 +21,8 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 RUN mkdir /paydb && chown -R appuser:appuser /paydb
 VOLUME /paydb
 
-ADD payd-server /bin
 ADD data/sqlite/migrations/ /migrations
+ADD payd-server /bin
 
 USER appuser:appuser
 


### PR DESCRIPTION
Currently, the goreleaser docker file adds the changing compiled binary to the output container as its first step, causing that layers shasum, and every layer after it, to be different. This means that, on image pull for an updated image, we have to pull all 7 layers.

Instead, we can add these files after the static files have been added, causing us to create only 2 new layers:
```
 => [stage-1 1/7] FROM docker.io/bitnami/minideb:buster@sha256:d892436645d96515daf4e925c68b522f4c892f91d4634ddcba463e3331748b10
 => [builder 1/2] FROM docker.io/library/golang:1.17.1-buster
 => CACHED [builder 2/2] RUN adduser     --disabled-password     --gecos ""     --no-create-home     --shell "/sbin/nologin"     --uid "10001"     "appuser"
 => CACHED [stage-1 2/7] COPY --from=builder /etc/passwd /etc/passwd
 => CACHED [stage-1 3/7] COPY --from=builder /etc/group /etc/group
 => CACHED [stage-1 4/7] COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 => CACHED [stage-1 5/7] RUN mkdir /paydb && chown -R appuser:appuser /paydb
 => [stage-1 6/7] ADD data/sqlite/migrations/ /migrations
 => [stage-1 7/7] ADD payd-server /bin
```