### PR TITLE
fix: replacing placeholder with token config

### DIFF
--- a/data/mapi/mapi.go
+++ b/data/mapi/mapi.go
@@ -31,7 +31,7 @@ func (m *minercraftMapi) Broadcast(ctx context.Context, tx *bt.Tx) error {
 		&minercraft.Transaction{
 			RawTx:              tx.String(),
 			CallBackURL:        "http://" + m.svrCfg.Hostname + "/api/v1/proofs/" + tx.TxID(),
-			CallBackToken:      "",
+			CallBackToken:      m.cfg.Token,
 			MerkleFormat:       "TSC",
 			CallBackEncryption: "",
 			MerkleProof:        true,


### PR DESCRIPTION
This changes nothing for main net configs but fixes the mapi callback problem on testnet with TAAL.

```yaml
# docker-compose.yml
services:
  payd:
    environment:
      WALLET_NETWORK: "testnet"
      MAPI_MINERURL: "https://mapi.taal.com"
      MAPI_TOKEN: "Bearer testnet_123456789ffa600482251a19e984f04d" # This PR ensures that this value is used
      MAPI_CALLBACK_URL: "https://yourdomainname.tld/api/v1/proofs"
```