### PR TITLE
Move DB_SCHEMA_PATH into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ VOLUME /paydb
 
 USER appuser:appuser
 
+ENV DB_SCHEMA_PATH=/migrations
 EXPOSE 8443
 
 CMD ["server"]

--- a/Dockerfile.releaser
+++ b/Dockerfile.releaser
@@ -57,6 +57,7 @@ ADD server /bin
 
 USER appuser:appuser
 
+ENV DB_SCHEMA_PATH=/migrations
 EXPOSE 8443
 
 CMD ["server"]

--- a/docker-compose.faucet.yml
+++ b/docker-compose.faucet.yml
@@ -6,7 +6,6 @@ services:
     image: local.payd
     environment:
       DB_DSN: "file:paydb/wallet.db?_foreign_keys=true&pooling=true"
-      DB_SCHEMA_PATH: "migrations"
       LOG_LEVEL: "debug"
       DPP_HOST: "wss://faucet.bitcoinsv.io/dpp/ws"
       MAPI_CALLBACK_HOST: "http://faucet.bitcoinsv.io/dpp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     image: local.payd
     environment:
       DB_DSN: "file:paydb/wallet.db?_foreign_keys=true&pooling=true"
-      DB_SCHEMA_PATH: "migrations"
       LOG_LEVEL: "info"
       DPP_HOST: "ws://dpp:8445/ws"
       MAPI_CALLBACK_HOST: "http://dpp:8445"
@@ -28,7 +27,6 @@ services:
     image: local.payd
     environment:
       DB_DSN: "file:paydb/merchant-wallet.db?_foreign_keys=true&pooling=true"
-      DB_SCHEMA_PATH: "migrations"
       SERVER_HOST: payd-merchant:28443
       SERVER_PORT: :28443
       LOG_LEVEL: "info"


### PR DESCRIPTION
DB_SCHEMA_PATH is a low-level dev setting. By moving it into the Dockerfile we can remove this setting from the docker-compose files while still making it available if needed.