### PR TITLE
Start using Go 1.18 in the github workflows for CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [1.16.x,1.17.x]
+        go-version: [1.17.x,1.18.x]
         os: [macos-latest,ubuntu-latest]
     name: lint
     runs-on: ${{ matrix.os }}
@@ -26,7 +26,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ 1.16.x,1.17.x ]
+        go-version: [ 1.17.x,1.18.x ]
         os: [ macos-latest, ubuntu-latest ]
     runs-on:  ${{ matrix.os }}
     steps:
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: release
         uses: goreleaser/goreleaser-action@v2
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Prepare for moving to Go 1.18

https://go.dev/doc/devel/release 