### PR TITLE
Don't fail to start up if can't subscribe to existing peer channels.

### DIFF
--- a/cmd/internal/internal.go
+++ b/cmd/internal/internal.go
@@ -131,7 +131,7 @@ func SetupHealthEndpoint(cfg config.Config, g *echo.Group, c *client.Client, dep
 }
 
 // ResumeActiveChannels resume listening to active peer channels.
-func ResumeActiveChannels(deps *SocketDeps) error {
+func ResumeActiveChannels(deps *SocketDeps, l log.Logger) error {
 	ctx := context.Background()
 	channels, err := deps.PeerChannelsService.ActiveProofChannels(ctx)
 	if err != nil {
@@ -141,7 +141,7 @@ func ResumeActiveChannels(deps *SocketDeps) error {
 	for _, channel := range channels {
 		ch := channel
 		if err := deps.PeerChannelsNotifyService.Subscribe(ctx, &ch); err != nil {
-			return err
+			l.Errorf(err, "failed to re-subscribe to channel %s", ch.ID)
 		}
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -102,7 +102,7 @@ func main() {
 
 	go func() {
 		for {
-			if err := internal.ResumeActiveChannels(deps); err != nil {
+			if err := internal.ResumeActiveChannels(deps, log); err != nil {
 				log.Fatal(err, "failed to resume active peer channels")
 			}
 			// retry channels we are waiting on in case the proof hasn't been received

--- a/docker-compose.faucet.yml
+++ b/docker-compose.faucet.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   payd:
     container_name: payd
-    image: local.payd
+    image: libsv/payd:0.1.11
     environment:
       DB_DSN: "file:paydb/wallet.db?_foreign_keys=true&pooling=true"
       LOG_LEVEL: "debug"
@@ -21,7 +21,7 @@ services:
 
   payd-merchant:
     container_name: payd-merchant
-    image: local.payd
+    image: libsv/payd:0.1.11
     volumes:
       - ./run/regtest/payd-merchant:/paydb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   payd:
     container_name: payd
-    image: local.payd
+    image: libsv/payd:0.1.11
     environment:
       DB_DSN: "file:paydb/wallet.db?_foreign_keys=true&pooling=true"
       LOG_LEVEL: "info"
@@ -24,7 +24,7 @@ services:
 
   payd-merchant:
     container_name: payd-merchant
-    image: local.payd
+    image: libsv/payd:0.1.11
     environment:
       DB_DSN: "file:paydb/merchant-wallet.db?_foreign_keys=true&pooling=true"
       SERVER_HOST: payd-merchant:28443


### PR DESCRIPTION
Currently if there is an error subscribing to an existing peer channel we will fail with a fatal error and stop the server. 

We don't want that as then the server won't start up, now we log an error and move on. 

This could occur if the token has been removed from the peerchannel server, perhaps as part of a db cleanup, or the peerchannel server has moved host or has since been taken down.